### PR TITLE
impl: Site L1 — App Scaffold

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Leagues Planner</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,1 @@
+export default { plugins: { tailwindcss: {}, autoprefixer: {} } }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,31 @@
+import { Routes, Route } from 'react-router-dom'
+import { LeagueProvider } from './contexts/LeagueContext'
+import { Header } from './components/Header'
+import { Footer } from './components/Footer'
+import { DashboardPage } from './pages/DashboardPage'
+import { TasksPage } from './pages/TasksPage'
+import { MapPage } from './pages/MapPage'
+import { PlannerPage } from './pages/PlannerPage'
+import { TrackerPage } from './pages/TrackerPage'
+import { SettingsPage } from './pages/SettingsPage'
+
+export default function App() {
+  return (
+    <LeagueProvider>
+      <div className="flex flex-col min-h-screen">
+        <Header />
+        <main className="flex-1 p-4">
+          <Routes>
+            <Route path="/" element={<DashboardPage />} />
+            <Route path="/tasks" element={<TasksPage />} />
+            <Route path="/map" element={<MapPage />} />
+            <Route path="/planner" element={<PlannerPage />} />
+            <Route path="/track" element={<TrackerPage />} />
+            <Route path="/settings" element={<SettingsPage />} />
+          </Routes>
+        </main>
+        <Footer />
+      </div>
+    </LeagueProvider>
+  )
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,14 @@
+export function Footer() {
+  return (
+    <footer className="px-4 py-2 text-xs text-gray-500 border-t border-gray-200">
+      Data sourced from the{' '}
+      <a href="https://oldschool.runescape.wiki" target="_blank" rel="noreferrer" className="underline">
+        OSRS Wiki
+      </a>
+      {' · '}
+      <a href="https://github.com/Kaqemeex/leagues-ui" target="_blank" rel="noreferrer" className="underline">
+        GitHub
+      </a>
+    </footer>
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,37 @@
+import { Link, NavLink } from 'react-router-dom'
+import { useLeague } from '../contexts/LeagueContext'
+
+export function Header() {
+  const { leagues, selectedLeagueId, setSelectedLeagueId } = useLeague()
+  return (
+    <header className="flex items-center gap-4 px-4 py-2 bg-gray-900 text-white">
+      <Link to="/" className="font-bold text-lg whitespace-nowrap">Leagues Planner</Link>
+      <select
+        value={selectedLeagueId}
+        onChange={e => setSelectedLeagueId(e.target.value)}
+        className="bg-gray-700 text-white rounded px-2 py-1 text-sm"
+      >
+        {leagues.map(l => <option key={l.id} value={l.id}>{l.name}</option>)}
+      </select>
+      <input
+        type="search"
+        placeholder="Search tasks…"
+        className="flex-1 bg-gray-700 text-white rounded px-2 py-1 text-sm"
+      />
+      <span className="text-sm bg-yellow-600 rounded px-2 py-1">0 pts</span>
+      <nav className="flex gap-3 text-sm">
+        {[
+          { to: '/tasks', label: 'Tasks' },
+          { to: '/map', label: 'Map' },
+          { to: '/planner', label: 'Planner' },
+          { to: '/track', label: 'Tracker' },
+          { to: '/settings', label: 'Settings' },
+        ].map(({ to, label }) => (
+          <NavLink key={to} to={to} className={({ isActive }) => isActive ? 'underline' : ''}>
+            {label}
+          </NavLink>
+        ))}
+      </nav>
+    </header>
+  )
+}

--- a/src/contexts/LeagueContext.tsx
+++ b/src/contexts/LeagueContext.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, useContext, useState } from 'react'
+
+interface LeagueInfo { id: string; name: string }
+
+// Stub — will be replaced by data/leagues/index.json once Assembly L5 is done
+const STUB_LEAGUES: LeagueInfo[] = [
+  { id: 'sample', name: 'Sample League' },
+]
+
+interface LeagueContextValue {
+  leagues: LeagueInfo[]
+  selectedLeagueId: string
+  setSelectedLeagueId: (id: string) => void
+}
+
+const LeagueContext = createContext<LeagueContextValue | null>(null)
+
+export function LeagueProvider({ children }: { children: React.ReactNode }) {
+  const [selectedLeagueId, setSelectedLeagueId] = useState(STUB_LEAGUES[0]?.id ?? '')
+  return (
+    <LeagueContext.Provider value={{ leagues: STUB_LEAGUES, selectedLeagueId, setSelectedLeagueId }}>
+      {children}
+    </LeagueContext.Provider>
+  )
+}
+
+export function useLeague(): LeagueContextValue {
+  const ctx = useContext(LeagueContext)
+  if (!ctx) throw new Error('useLeague must be used within LeagueProvider')
+  return ctx
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+)

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,0 +1,3 @@
+export function DashboardPage() {
+  return <h1>Dashboard</h1>
+}

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -1,0 +1,3 @@
+export function MapPage() {
+  return <h1>Map</h1>
+}

--- a/src/pages/PlannerPage.tsx
+++ b/src/pages/PlannerPage.tsx
@@ -1,0 +1,3 @@
+export function PlannerPage() {
+  return <h1>Planner</h1>
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,0 +1,3 @@
+export function SettingsPage() {
+  return <h1>Settings</h1>
+}

--- a/src/pages/TasksPage.tsx
+++ b/src/pages/TasksPage.tsx
@@ -1,0 +1,3 @@
+export function TasksPage() {
+  return <h1>Tasks</h1>
+}

--- a/src/pages/TrackerPage.tsx
+++ b/src/pages/TrackerPage.tsx
@@ -1,0 +1,3 @@
+export function TrackerPage() {
+  return <h1>Tracker</h1>
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,6 @@
+import type { Config } from 'tailwindcss'
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: { extend: {} },
+  plugins: [],
+} satisfies Config

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+export default defineConfig({ plugins: [react()] })


### PR DESCRIPTION
## Site Layer 1 — App Scaffold

Vite + React + TypeScript project with routing, nav shell, league selector context, and stub pages for all 6 routes.

### Deliverables
- `index.html`, `vite.config.ts`, `tailwind.config.ts`, `postcss.config.js`
- `src/main.tsx` — ReactDOM entry point
- `src/App.tsx` — BrowserRouter + LeagueProvider + layout shell
- `src/contexts/LeagueContext.tsx` — league selector context + useLeague hook (stub list, swappable for index.json)
- `src/components/Header.tsx` — nav, league selector, search bar placeholder, points chip placeholder
- `src/components/Footer.tsx` — OSRS Wiki attribution + GitHub link
- `src/pages/` — 6 stub pages (Dashboard, Tasks, Map, Planner, Tracker, Settings)

### Acceptance criteria
- [x] `npm run dev` starts without errors
- [x] All 6 routes render stub headings
- [x] Header + Footer on every route
- [x] League selector updates LeagueContext
- [x] `tsc --noEmit` exits 0

### Dependencies
- Builds on Data L1 (PR #8) for package.json/tsconfig.json foundation