### PR TITLE
impl: Data L2 — Spatial Schema

### DIFF
--- a/data/leagues/sample.json
+++ b/data/leagues/sample.json
@@ -106,5 +106,60 @@
     { "tier": "Iron", "pointsRequired": 500 },
     { "tier": "Steel", "pointsRequired": 1500 },
     { "tier": "Mithril", "pointsRequired": 3000 }
+  ],
+  "locations": [
+    {
+      "id": "loc-lumbridge",
+      "name": "Lumbridge",
+      "activityTypes": ["woodcutting", "cooking", "combat", "quest", "thieving"],
+      "tile": { "x": 3222, "y": 3218, "plane": 0 },
+      "regionId": "misthalin",
+      "notes": "Starting area with castle, trees, and fishing spots."
+    },
+    {
+      "id": "loc-varrock",
+      "name": "Varrock",
+      "activityTypes": ["combat", "mining", "smithing", "magic", "quest"],
+      "tile": { "x": 3210, "y": 3424, "plane": 0 },
+      "regionId": "misthalin",
+      "notes": "Major city with grand exchange, mine to the south, and various quest NPCs."
+    },
+    {
+      "id": "loc-al-kharid",
+      "name": "Al Kharid",
+      "activityTypes": ["smithing", "mining", "thieving", "combat", "crafting"],
+      "tile": { "x": 3293, "y": 3174, "plane": 0 },
+      "regionId": "misthalin",
+      "notes": "Desert city with furnace for smelting and mine nearby."
+    },
+    {
+      "id": "loc-draynor",
+      "name": "Draynor Village",
+      "activityTypes": ["fishing", "thieving", "woodcutting", "quest"],
+      "tile": { "x": 3092, "y": 3243, "plane": 0 },
+      "regionId": "misthalin",
+      "notes": "Quiet village with a jail, fishing spots, and Draynor manor nearby."
+    },
+    {
+      "id": "loc-karamja-agility",
+      "name": "Karamja Agility Course",
+      "activityTypes": ["agility", "fishing", "combat", "slayer"],
+      "tile": { "x": 2755, "y": 3144, "plane": 0 },
+      "regionId": "karamja",
+      "notes": "Brimhaven agility arena and Karamja fishing spots. Also home to TzHaar city and the Inferno."
+    }
+  ],
+  "taskLocations": [
+    { "taskId": "task-001", "locationId": "loc-lumbridge", "isPrimary": true },
+    { "taskId": "task-002", "locationId": "loc-lumbridge", "isPrimary": true },
+    { "taskId": "task-003", "locationId": "loc-draynor", "isPrimary": true },
+    { "taskId": "task-003", "locationId": "loc-varrock", "isPrimary": false },
+    { "taskId": "task-004", "locationId": "loc-lumbridge", "isPrimary": true },
+    { "taskId": "task-005", "locationId": "loc-al-kharid", "isPrimary": true },
+    { "taskId": "task-006", "locationId": "loc-varrock", "isPrimary": true },
+    { "taskId": "task-007", "locationId": "loc-karamja-agility", "isPrimary": true },
+    { "taskId": "task-008", "locationId": "loc-karamja-agility", "isPrimary": true },
+    { "taskId": "task-009", "locationId": "loc-karamja-agility", "isPrimary": true },
+    { "taskId": "task-010", "locationId": "loc-karamja-agility", "isPrimary": true }
   ]
 }

--- a/src/schemas/core.ts
+++ b/src/schemas/core.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { LocationSchema, TaskLocationSchema } from './location.js'
 
 export const SkillSchema = z.enum([
   'Attack',
@@ -56,6 +57,8 @@ export const LeagueSchema = z.object({
   regions: z.array(RegionSchema),
   tasks: z.array(TaskSchema),
   pointTiers: z.array(PointTierSchema),
+  locations: z.array(LocationSchema).optional(),
+  taskLocations: z.array(TaskLocationSchema).optional(),
 })
 
 export type Skill = z.infer<typeof SkillSchema>

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,1 +1,2 @@
 export * from './core.js'
+export * from './location.js'

--- a/src/schemas/location.ts
+++ b/src/schemas/location.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod'
+
+export const ActivityTypeSchema = z.enum([
+  'agility', 'mining', 'fishing', 'slayer', 'farming',
+  'woodcutting', 'runecraft', 'smithing', 'cooking',
+  'firemaking', 'thieving', 'herblore', 'crafting',
+  'fletching', 'hunter', 'construction', 'prayer',
+  'magic', 'combat', 'quest', 'other'
+])
+export type ActivityType = z.infer<typeof ActivityTypeSchema>
+
+export const TileSchema = z.object({
+  x: z.number().int(),
+  y: z.number().int(),
+  plane: z.number().int().min(0).max(3).default(0),
+})
+export type Tile = z.infer<typeof TileSchema>
+
+// LocationRef is a string alias — the id field of a Location
+export type LocationRef = string
+
+export const LocationSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  activityTypes: z.array(ActivityTypeSchema),
+  tile: TileSchema,
+  regionId: z.string(),
+  notes: z.string().optional(),
+})
+export type Location = z.infer<typeof LocationSchema>
+
+export const TaskLocationSchema = z.object({
+  taskId: z.string(),
+  locationId: z.string(), // LocationRef
+  isPrimary: z.boolean().default(true),
+})
+export type TaskLocation = z.infer<typeof TaskLocationSchema>


### PR DESCRIPTION
## Data Layer 2 — Spatial Schema

Adds Location, TaskLocation, ActivityType, and Tile schemas. Every task in sample data now has ≥1 resolved LocationId.

### Deliverables
- `src/schemas/location.ts` — LocationSchema, TaskLocationSchema, ActivityTypeSchema, TileSchema, LocationRef type alias
- Updated `LeagueSchema` in core.ts to include optional locations + taskLocations arrays
- Updated `data/leagues/sample.json` with 5 locations and task→location links

### Acceptance criteria
- [x] tsc --noEmit exits 0
- [x] Every task in sample.json has ≥1 resolved LocationId via taskLocations
- [x] LocationRef type alias defined