### PR TITLE
impl: Site L2 — Static Pages

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,0 +1,17 @@
+import { LeagueSchema, type League } from '../schemas/index.js'
+
+// During dev, import sample.json directly. In future, this will load dynamically.
+import sampleData from '../../data/leagues/sample.json' with { type: 'json' }
+
+const leagueCache = new Map<string, League>()
+
+export function loadLeague(leagueId: string): League | null {
+  if (leagueCache.has(leagueId)) return leagueCache.get(leagueId)!
+  if (leagueId === 'sample') {
+    const result = LeagueSchema.safeParse(sampleData)
+    if (!result.success) { console.error('Invalid sample data', result.error); return null }
+    leagueCache.set(leagueId, result.data)
+    return result.data
+  }
+  return null
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,3 +1,35 @@
+import { useLeague } from '../contexts/LeagueContext'
+import { loadLeague } from '../lib/data'
+
 export function DashboardPage() {
-  return <h1>Dashboard</h1>
+  const { selectedLeagueId } = useLeague()
+  const league = loadLeague(selectedLeagueId)
+
+  const totalPoints = league?.tasks.reduce((sum, t) => sum + t.points, 0) ?? 0
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">{league?.name ?? 'No league selected'}</h1>
+        <span className="text-lg font-mono bg-yellow-100 text-yellow-800 px-3 py-1 rounded">
+          0 / {totalPoints} pts
+        </span>
+      </div>
+
+      <section className="border rounded p-4 space-y-2">
+        <h2 className="text-lg font-semibold">Tier Progress</h2>
+        <p className="text-gray-500 text-sm">No tiers unlocked yet.</p>
+      </section>
+
+      <section className="border rounded p-4 space-y-2">
+        <h2 className="text-lg font-semibold">Region Unlocks</h2>
+        <p className="text-gray-500 text-sm">No regions unlocked yet.</p>
+      </section>
+
+      <section className="border rounded p-4 space-y-2">
+        <h2 className="text-lg font-semibold">Active List</h2>
+        <p className="text-gray-500 text-sm">No tasks in active list.</p>
+      </section>
+    </div>
+  )
 }

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -1,3 +1,7 @@
 export function MapPage() {
-  return <h1>Map</h1>
+  return (
+    <div className="flex items-center justify-center" style={{ height: 'calc(100vh - 8rem)' }}>
+      <p className="text-2xl text-gray-400 font-medium">Map coming soon</p>
+    </div>
+  )
 }

--- a/src/pages/PlannerPage.tsx
+++ b/src/pages/PlannerPage.tsx
@@ -1,3 +1,16 @@
 export function PlannerPage() {
-  return <h1>Planner</h1>
+  return (
+    <div className="flex gap-4 h-full" style={{ minHeight: 'calc(100vh - 8rem)' }}>
+      {/* Task list — left column */}
+      <aside className="w-80 border rounded p-4 flex flex-col gap-2">
+        <h2 className="font-semibold text-sm uppercase text-gray-500 tracking-wide">Task List</h2>
+        <p className="text-gray-400 text-sm">No tasks selected.</p>
+      </aside>
+
+      {/* Map — right column */}
+      <div className="flex-1 border rounded flex items-center justify-center bg-gray-50">
+        <p className="text-gray-400 text-lg">Map placeholder</p>
+      </div>
+    </div>
+  )
 }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,3 +1,47 @@
+import { useLeague } from '../contexts/LeagueContext'
+
 export function SettingsPage() {
-  return <h1>Settings</h1>
+  const { leagues, selectedLeagueId, setSelectedLeagueId } = useLeague()
+
+  return (
+    <div className="max-w-lg mx-auto space-y-8">
+      <h1 className="text-2xl font-bold">Settings</h1>
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold">League</h2>
+        <div className="flex flex-col gap-1">
+          <label htmlFor="league-select" className="text-sm text-gray-600">Active league</label>
+          <select
+            id="league-select"
+            value={selectedLeagueId}
+            onChange={e => setSelectedLeagueId(e.target.value)}
+            className="border rounded px-3 py-2 text-sm"
+          >
+            {leagues.map(l => (
+              <option key={l.id} value={l.id}>{l.name}</option>
+            ))}
+          </select>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold">Preferences</h2>
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center justify-between">
+            <label className="text-sm text-gray-600">Show completed tasks</label>
+            <input type="checkbox" className="w-4 h-4" disabled />
+          </div>
+          <div className="flex items-center justify-between">
+            <label className="text-sm text-gray-600">Dark mode</label>
+            <input type="checkbox" className="w-4 h-4" disabled />
+          </div>
+          <div className="flex items-center justify-between">
+            <label className="text-sm text-gray-600">Compact task list</label>
+            <input type="checkbox" className="w-4 h-4" disabled />
+          </div>
+        </div>
+        <p className="text-xs text-gray-400">Preferences are not saved yet.</p>
+      </section>
+    </div>
+  )
 }

--- a/src/pages/TasksPage.tsx
+++ b/src/pages/TasksPage.tsx
@@ -1,3 +1,39 @@
+import { useLeague } from '../contexts/LeagueContext'
+import { loadLeague } from '../lib/data'
+
 export function TasksPage() {
-  return <h1>Tasks</h1>
+  const { selectedLeagueId } = useLeague()
+  const league = loadLeague(selectedLeagueId)
+
+  if (!league) {
+    return <p className="text-gray-500">No data available</p>
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">{league.name} — Tasks</h1>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm border-collapse">
+          <thead>
+            <tr className="bg-gray-100 text-left">
+              <th className="px-3 py-2 border">Name</th>
+              <th className="px-3 py-2 border">Region</th>
+              <th className="px-3 py-2 border">Difficulty</th>
+              <th className="px-3 py-2 border text-right">Points</th>
+            </tr>
+          </thead>
+          <tbody>
+            {league.tasks.map(task => (
+              <tr key={task.id} className="odd:bg-white even:bg-gray-50 hover:bg-yellow-50">
+                <td className="px-3 py-2 border font-medium">{task.name}</td>
+                <td className="px-3 py-2 border capitalize">{task.region}</td>
+                <td className="px-3 py-2 border">{task.difficulty}</td>
+                <td className="px-3 py-2 border text-right font-mono">{task.points}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
 }

--- a/src/pages/TrackerPage.tsx
+++ b/src/pages/TrackerPage.tsx
@@ -1,3 +1,33 @@
+import { useLeague } from '../contexts/LeagueContext'
+import { loadLeague } from '../lib/data'
+
 export function TrackerPage() {
-  return <h1>Tracker</h1>
+  const { selectedLeagueId } = useLeague()
+  const league = loadLeague(selectedLeagueId)
+
+  if (!league) {
+    return <p className="text-gray-500">No data available</p>
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">{league.name} — Tracker</h1>
+      <ul className="space-y-2">
+        {league.tasks.map(task => (
+          <li key={task.id} className="flex items-center gap-3 border rounded px-3 py-2 hover:bg-gray-50">
+            <input
+              type="checkbox"
+              id={`task-${task.id}`}
+              className="w-4 h-4 accent-yellow-600"
+              defaultChecked={false}
+            />
+            <label htmlFor={`task-${task.id}`} className="flex-1 cursor-pointer">
+              <span className="font-medium">{task.name}</span>
+              <span className="ml-2 text-xs text-gray-400">{task.difficulty} · {task.points} pts</span>
+            </label>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "jsx": "react-jsx",
     "strict": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
## Site Layer 2 — Static Pages

Every route renders real content; /tasks loads and displays the full task list from sample.json.

### Deliverables
- `src/lib/data.ts` — loadLeague() utility with Zod validation and in-memory cache
- Updated DashboardPage — league name, points placeholder, section stubs
- Updated TasksPage — full task table (name, region, difficulty, points) from active league data
- Updated MapPage — viewport-filling placeholder
- Updated PlannerPage — two-column layout stub
- Updated TrackerPage — all tasks with unchecked checkboxes
- Updated SettingsPage — league selector + preference stubs

### Acceptance criteria
- [x] Every route reachable without blank screen or console error
- [x] /tasks renders one row per task in sample.json
- [x] tsc --noEmit exits 0
- [x] npm run build exits 0