### PR TITLE
impl: Assembly L1 — Raw Scrapers

### DIFF
--- a/data/raw/category-map.json
+++ b/data/raw/category-map.json
@@ -1,0 +1,22 @@
+{
+  "Agility_training_areas": "agility",
+  "Mining_sites": "mining",
+  "Fishing_spots": "fishing",
+  "Slayer_masters": "slayer",
+  "Farming_patches": "farming",
+  "Woodcutting_trees": "woodcutting",
+  "Runecrafting_altars": "runecraft",
+  "Smithing_locations": "smithing",
+  "Cooking_ranges": "cooking",
+  "Firemaking_locations": "firemaking",
+  "Thieving_locations": "thieving",
+  "Herblore_locations": "herblore",
+  "Crafting_locations": "crafting",
+  "Fletching_locations": "fletching",
+  "Hunter_locations": "hunter",
+  "Construction_locations": "construction",
+  "Prayer_locations": "prayer",
+  "Magic_training_areas": "magic",
+  "Combat_training_areas": "combat",
+  "Quest_start_points": "quest"
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "tsc && vite build",
     "typecheck": "tsc --noEmit",
     "validate-data": "tsx scripts/build-data.ts",
-    "scrape": "tsx scripts/scrape-tasks.ts"
+    "scrape": "tsx scripts/scrape-tasks.ts",
+    "scrape:tasks": "tsx scripts/scrape-tasks.ts",
+    "scrape:locations": "tsx scripts/scrape-locations.ts"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/scripts/lib/wiki-client.ts
+++ b/scripts/lib/wiki-client.ts
@@ -1,0 +1,127 @@
+/**
+ * Rate-limited OSRS Wiki API client with disk cache.
+ *
+ * - Base URL: https://oldschool.runescape.wiki/api.php
+ * - Rate limit: 1 req/s
+ * - Disk cache: data/raw/.cache/{sha256-of-params}.json
+ * - User-Agent per wiki bot policy
+ */
+
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs'
+import * as https from 'node:https'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const WIKI_BASE_URL = 'https://oldschool.runescape.wiki/api.php'
+const USER_AGENT =
+  'leagues-planner-scraper/1.0 (contact: github.com/Kaqemeex/leagues-ui)'
+const CACHE_DIR = path.resolve(__dirname, '../../data/raw/.cache')
+
+/** Milliseconds between requests to stay within 1 req/s */
+const MIN_INTERVAL_MS = 1000
+
+let lastRequestAt = 0
+
+function getCachePath(params: Record<string, string>): string {
+  const canonical = JSON.stringify(
+    Object.entries(params)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .reduce<Record<string, string>>((acc, [k, v]) => {
+        acc[k] = v
+        return acc
+      }, {}),
+  )
+  const hash = crypto.createHash('sha256').update(canonical).digest('hex')
+  return path.join(CACHE_DIR, `${hash}.json`)
+}
+
+function readCache(cachePath: string): unknown | null {
+  try {
+    const raw = fs.readFileSync(cachePath, 'utf-8')
+    return JSON.parse(raw) as unknown
+  } catch {
+    return null
+  }
+}
+
+function writeCache(cachePath: string, data: unknown): void {
+  fs.mkdirSync(CACHE_DIR, { recursive: true })
+  fs.writeFileSync(cachePath, JSON.stringify(data, null, 2), 'utf-8')
+}
+
+function buildUrl(params: Record<string, string>): string {
+  const allParams: Record<string, string> = { ...params, format: 'json' }
+  const qs = Object.entries(allParams)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join('&')
+  return `${WIKI_BASE_URL}?${qs}`
+}
+
+function httpGet(url: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const options = {
+      headers: { 'User-Agent': USER_AGENT },
+    }
+    const req = https.get(url, options, (res) => {
+      if (res.statusCode !== 200) {
+        reject(
+          new Error(
+            `HTTP error: ${res.statusCode} ${res.statusMessage ?? ''} for ${url}`,
+          ),
+        )
+        res.resume()
+        return
+      }
+      const chunks: Buffer[] = []
+      res.on('data', (chunk: Buffer) => chunks.push(chunk))
+      res.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')))
+      res.on('error', reject)
+    })
+    req.on('error', reject)
+    req.end()
+  })
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Make a request to the OSRS Wiki API, returning the parsed JSON response.
+ *
+ * Responses are cached to disk by SHA-256 of the parameter set. A cached
+ * hit returns immediately without making any HTTP request.
+ *
+ * Uncached requests are rate-limited to 1 req/s.
+ *
+ * @throws Error if the HTTP response status is not 200.
+ */
+export async function wikiRequest(
+  params: Record<string, string>,
+): Promise<unknown> {
+  const cachePath = getCachePath(params)
+
+  const cached = readCache(cachePath)
+  if (cached !== null) {
+    return cached
+  }
+
+  // Rate limiting: ensure at least MIN_INTERVAL_MS between requests
+  const now = Date.now()
+  const elapsed = now - lastRequestAt
+  if (elapsed < MIN_INTERVAL_MS) {
+    await sleep(MIN_INTERVAL_MS - elapsed)
+  }
+  lastRequestAt = Date.now()
+
+  const url = buildUrl(params)
+  const raw = await httpGet(url)
+  const data: unknown = JSON.parse(raw)
+
+  writeCache(cachePath, data)
+  return data
+}

--- a/scripts/scrape-locations.ts
+++ b/scripts/scrape-locations.ts
@@ -1,0 +1,228 @@
+/**
+ * Scrape map marker / location data from the OSRS Wiki for each activity category.
+ *
+ * Usage:
+ *   tsx scripts/scrape-locations.ts --league <league-id>
+ *
+ * Example:
+ *   tsx scripts/scrape-locations.ts --league trailblazer-reloaded
+ *
+ * Output: data/raw/<league-id>/raw-locations.json
+ *
+ * Uses the wiki geosearch API and the category-map.json file to enumerate all
+ * relevant map marker categories. Results are cached so re-runs make 0 HTTP
+ * requests.
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { wikiRequest } from './lib/wiki-client.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface RawLocation {
+  name: string
+  category: string
+  activityType: string
+  tile: { x: number; y: number; plane: number }
+}
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(): { league: string } {
+  const args = process.argv.slice(2)
+  const leagueIdx = args.indexOf('--league')
+  if (leagueIdx === -1 || !args[leagueIdx + 1]) {
+    console.error(
+      'Usage: tsx scripts/scrape-locations.ts --league <league-id>',
+    )
+    process.exit(1)
+  }
+  const league = args[leagueIdx + 1]!
+  return { league }
+}
+
+// ---------------------------------------------------------------------------
+// Category map
+// ---------------------------------------------------------------------------
+
+function loadCategoryMap(): Record<string, string> {
+  const mapPath = path.resolve(__dirname, '../data/raw/category-map.json')
+  const raw = fs.readFileSync(mapPath, 'utf-8')
+  return JSON.parse(raw) as Record<string, string>
+}
+
+// ---------------------------------------------------------------------------
+// API response types
+// ---------------------------------------------------------------------------
+
+interface GeoSearchResult {
+  pageid?: number
+  ns?: number
+  title?: string
+  lat?: number
+  lon?: number
+  dist?: number
+  primary?: string
+}
+
+interface GeoSearchResponse {
+  query?: {
+    geosearch?: GeoSearchResult[]
+  }
+  error?: {
+    code?: string
+    info?: string
+  }
+  'query-continue'?: unknown
+}
+
+/**
+ * Fetch all geosearch results for a given wiki category label (the
+ * category-map.json key, e.g. "Woodcutting_trees").
+ *
+ * The wiki's geosearch API returns map marker data. We use `gscoord` with a
+ * very large radius to capture the entire game map, and page through results
+ * using `gsoffset`.
+ *
+ * Note: The OSRS wiki geosearch endpoint uses coordinates centred on the
+ * OSRS world map. Lumbridge is approximately (3222, 3218) in OSRS tile coords,
+ * which maps to roughly (lat=3218, lon=3222) in the wiki's coordinate system.
+ * We query from the approximate map centre with a large radius.
+ */
+async function fetchCategoryLocations(
+  categoryLabel: string,
+): Promise<GeoSearchResult[]> {
+  const results: GeoSearchResult[] = []
+  const limit = 500
+
+  // Centre of the OSRS map (approximate world centre tile)
+  // We use a radius of 20000 game tiles to capture the full world
+  const params: Record<string, string> = {
+    action: 'query',
+    list: 'geosearch',
+    gscoord: '3200|3200',
+    gsradius: '20000',
+    gslimit: String(limit),
+    gsprop: 'type|name|dim|country|region|globe',
+    gsglobe: 'Gielinor',
+    // Filter by category if supported (wiki uses "type" for map marker category)
+    gstype: categoryLabel,
+  }
+
+  let response: GeoSearchResponse
+  try {
+    response = (await wikiRequest(params)) as GeoSearchResponse
+  } catch (err) {
+    console.warn(
+      `  Warning: HTTP error fetching category "${categoryLabel}": ${String(err)}`,
+    )
+    return results
+  }
+
+  if (response.error) {
+    // Gracefully skip categories the API doesn't recognise
+    console.warn(
+      `  Warning: API error for category "${categoryLabel}": ${response.error.info ?? response.error.code ?? 'unknown'}`,
+    )
+    return results
+  }
+
+  const hits = response.query?.geosearch ?? []
+  results.push(...hits)
+  return results
+}
+
+// ---------------------------------------------------------------------------
+// Tile coordinate conversion
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert wiki geosearch coordinates to OSRS tile coords.
+ *
+ * The OSRS wiki uses (lat=y_tile, lon=x_tile) for the Gielinor globe.
+ * Plane is not returned by geosearch and defaults to 0.
+ */
+function toTile(
+  hit: GeoSearchResult,
+): { x: number; y: number; plane: number } {
+  return {
+    x: Math.round(hit.lon ?? 0),
+    y: Math.round(hit.lat ?? 0),
+    plane: 0,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Deduplication
+// ---------------------------------------------------------------------------
+
+function deduplicateLocations(locations: RawLocation[]): RawLocation[] {
+  const seen = new Set<string>()
+  const unique: RawLocation[] = []
+  for (const loc of locations) {
+    const key = `${loc.name}|${loc.tile.x}|${loc.tile.y}|${loc.tile.plane}`
+    if (!seen.has(key)) {
+      seen.add(key)
+      unique.push(loc)
+    }
+  }
+  return unique
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const { league } = parseArgs()
+
+  console.log(`Scraping locations for league: ${league}`)
+
+  const categoryMap = loadCategoryMap()
+  const categories = Object.entries(categoryMap)
+  console.log(`Processing ${categories.length} categories from category-map.json…`)
+
+  const allLocations: RawLocation[] = []
+
+  for (const [categoryLabel, activityType] of categories) {
+    console.log(`  Fetching: ${categoryLabel} → ${activityType}`)
+    const hits = await fetchCategoryLocations(categoryLabel)
+    console.log(`    Got ${hits.length} result(s)`)
+
+    for (const hit of hits) {
+      if (!hit.title) continue
+      allLocations.push({
+        name: hit.title,
+        category: categoryLabel,
+        activityType,
+        tile: toTile(hit),
+      })
+    }
+  }
+
+  const deduplicated = deduplicateLocations(allLocations)
+  console.log(
+    `Total: ${allLocations.length} raw → ${deduplicated.length} after deduplication`,
+  )
+
+  const outDir = path.resolve(__dirname, '../data/raw', league)
+  fs.mkdirSync(outDir, { recursive: true })
+  const outPath = path.join(outDir, 'raw-locations.json')
+
+  fs.writeFileSync(outPath, JSON.stringify(deduplicated, null, 2), 'utf-8')
+  console.log(`Wrote ${deduplicated.length} location(s) to ${outPath}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/scrape-tasks.ts
+++ b/scripts/scrape-tasks.ts
@@ -1,0 +1,352 @@
+/**
+ * Scrape league task data from the OSRS Wiki.
+ *
+ * Usage:
+ *   tsx scripts/scrape-tasks.ts --league <league-id>
+ *
+ * Example:
+ *   tsx scripts/scrape-tasks.ts --league trailblazer-reloaded
+ *
+ * Output: data/raw/<league-id>/raw-tasks.json
+ *
+ * The scraper merges new tasks into any existing file by task name without
+ * modifying existing entries.
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { wikiRequest } from './lib/wiki-client.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface RawTask {
+  name: string
+  description: string
+  difficulty: string
+  skills: string[]
+  points: number
+  region: string
+}
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(): { league: string } {
+  const args = process.argv.slice(2)
+  const leagueIdx = args.indexOf('--league')
+  if (leagueIdx === -1 || !args[leagueIdx + 1]) {
+    console.error('Usage: tsx scripts/scrape-tasks.ts --league <league-id>')
+    process.exit(1)
+  }
+  const league = args[leagueIdx + 1]!
+  return { league }
+}
+
+// ---------------------------------------------------------------------------
+// League ID → Wiki page title
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a kebab-case league ID to a MediaWiki page title.
+ *
+ * "trailblazer-reloaded"  → "Trailblazer_Reloaded_League/Tasks"
+ * "trailblazer"           → "Trailblazer_League/Tasks"
+ * "raging-echoes"         → "Raging_Echoes_League/Tasks"
+ */
+function leagueIdToPageTitle(leagueId: string): string {
+  const titleCase = leagueId
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('_')
+  return `${titleCase}_League/Tasks`
+}
+
+// ---------------------------------------------------------------------------
+// Wikitext parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract skill names referenced in a task template call or description.
+ * Returns an empty array when no skills can be determined.
+ */
+function extractSkills(text: string): string[] {
+  const skillNames = [
+    'Attack',
+    'Strength',
+    'Defence',
+    'Ranged',
+    'Prayer',
+    'Magic',
+    'Runecraft',
+    'Construction',
+    'Hitpoints',
+    'Agility',
+    'Herblore',
+    'Thieving',
+    'Crafting',
+    'Fletching',
+    'Slayer',
+    'Hunter',
+    'Mining',
+    'Smithing',
+    'Fishing',
+    'Cooking',
+    'Firemaking',
+    'Woodcutting',
+    'Farming',
+  ]
+  const found: string[] = []
+  const lower = text.toLowerCase()
+  for (const skill of skillNames) {
+    if (lower.includes(skill.toLowerCase())) {
+      found.push(skill)
+    }
+  }
+  return found
+}
+
+/**
+ * Parse points from wikitext — handles plain numbers and template calls.
+ */
+function parsePoints(raw: string): number {
+  const trimmed = raw.trim()
+  const n = parseInt(trimmed, 10)
+  return isNaN(n) ? 0 : n
+}
+
+/**
+ * Strip wiki markup from a string (links, templates, bold/italic markers).
+ */
+function stripWikiMarkup(text: string): string {
+  return text
+    .replace(/\[\[(?:[^|\]]*\|)?([^\]]+)\]\]/g, '$1') // [[link|text]] → text
+    .replace(/{{[^}]*}}/g, '')                          // remove templates
+    .replace(/'{2,3}/g, '')                             // bold/italic
+    .trim()
+}
+
+/**
+ * Parse tasks from MediaWiki wikitext.
+ *
+ * The OSRS Wiki task pages use the {{Leagues task}} template:
+ *
+ *   {{Leagues task
+ *   |name=...
+ *   |description=...
+ *   |difficulty=...
+ *   |points=...
+ *   |region=...
+ *   |skills=...
+ *   }}
+ *
+ * Falls back to basic wiki-table row parsing when templates are absent.
+ */
+function parseWikitext(wikitext: string): RawTask[] {
+  const tasks: RawTask[] = []
+
+  // -------------------------------------------------------------------------
+  // Strategy 1: {{Leagues task}} template blocks
+  // -------------------------------------------------------------------------
+  const templateRegex = /\{\{Leagues[ _]task\s*\n([\s\S]*?)\n\}\}/gi
+  let match: RegExpExecArray | null
+  while ((match = templateRegex.exec(wikitext)) !== null) {
+    const block = match[1] ?? ''
+    const get = (key: string): string => {
+      const lineMatch = new RegExp(
+        `^\\s*\\|\\s*${key}\\s*=\\s*(.*)$`,
+        'im',
+      ).exec(block)
+      return lineMatch ? stripWikiMarkup(lineMatch[1] ?? '') : ''
+    }
+
+    const name = get('name')
+    if (!name) continue
+
+    const description = get('description')
+    const difficulty = get('difficulty') || 'Easy'
+    const pointsRaw = get('points')
+    const region = get('region') || get('area') || 'Unknown'
+    const skillsRaw = get('skills')
+
+    const skills =
+      skillsRaw
+        .split(/[,\s]+/)
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0) || extractSkills(description)
+
+    tasks.push({
+      name,
+      description,
+      difficulty,
+      skills,
+      points: parsePoints(pointsRaw),
+      region,
+    })
+  }
+
+  if (tasks.length > 0) return tasks
+
+  // -------------------------------------------------------------------------
+  // Strategy 2: Wiki table rows  |name||description||difficulty||points||...
+  // -------------------------------------------------------------------------
+  let currentRegion = 'Unknown'
+  const lines = wikitext.split('\n')
+
+  for (const line of lines) {
+    // Section header (== Region Name ==)
+    const sectionMatch = /^==+\s*([^=]+?)\s*==+/.exec(line)
+    if (sectionMatch) {
+      currentRegion = stripWikiMarkup(sectionMatch[1] ?? '').trim()
+      continue
+    }
+
+    // Table row starting with |-  (row separator — skip)
+    if (/^\s*\|-/.test(line)) continue
+
+    // Table row with pipe-delimited cells
+    const cells = line
+      .split('||')
+      .map((c) => stripWikiMarkup(c.replace(/^\s*\|/, '').trim()))
+
+    if (cells.length >= 3) {
+      const [name, description, difficulty, pointsStr] = cells
+      if (!name || !description) continue
+      // Heuristic: check if first cell looks like a task name (not a header)
+      if (/^(task|name|!)/i.test(name)) continue
+
+      tasks.push({
+        name,
+        description: description ?? '',
+        difficulty: difficulty ?? 'Easy',
+        skills: extractSkills(description ?? ''),
+        points: parsePoints(pointsStr ?? '0'),
+        region: currentRegion,
+      })
+    }
+  }
+
+  return tasks
+}
+
+// ---------------------------------------------------------------------------
+// File I/O helpers
+// ---------------------------------------------------------------------------
+
+function readExistingTasks(filePath: string): RawTask[] {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8')
+    return JSON.parse(raw) as RawTask[]
+  } catch {
+    return []
+  }
+}
+
+function mergeTasks(existing: RawTask[], incoming: RawTask[]): RawTask[] {
+  const byName = new Map<string, RawTask>()
+  for (const task of existing) {
+    byName.set(task.name, task)
+  }
+  let added = 0
+  for (const task of incoming) {
+    if (!byName.has(task.name)) {
+      byName.set(task.name, task)
+      added++
+    }
+  }
+  if (added > 0) {
+    console.log(`  Added ${added} new task(s).`)
+  } else {
+    console.log('  No new tasks — file unchanged.')
+  }
+  return Array.from(byName.values())
+}
+
+// ---------------------------------------------------------------------------
+// API response types
+// ---------------------------------------------------------------------------
+
+interface ParseResponse {
+  parse?: {
+    wikitext?: {
+      '*'?: string
+    }
+  }
+  error?: {
+    code?: string
+    info?: string
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const { league } = parseArgs()
+
+  const pageTitle = leagueIdToPageTitle(league)
+  console.log(`Scraping tasks for league: ${league}`)
+  console.log(`Wiki page: ${pageTitle}`)
+
+  let response: ParseResponse
+  try {
+    response = (await wikiRequest({
+      action: 'parse',
+      page: pageTitle,
+      prop: 'wikitext',
+    })) as ParseResponse
+  } catch (err) {
+    console.error(`HTTP error fetching wiki page: ${String(err)}`)
+    process.exit(1)
+  }
+
+  // Handle missing page
+  if (response.error) {
+    const code = response.error.code ?? ''
+    if (code === 'missingtitle' || code === 'missing') {
+      console.warn(
+        `Warning: Wiki page "${pageTitle}" not found (${response.error.info ?? code}).`,
+      )
+      console.warn('This is expected for leagues not yet documented on the wiki.')
+      process.exit(0)
+    }
+    console.error(`Wiki API error: ${response.error.info ?? code}`)
+    process.exit(1)
+  }
+
+  const wikitext = response.parse?.wikitext?.['*'] ?? ''
+  if (!wikitext) {
+    console.warn(`Warning: Wiki page "${pageTitle}" returned empty wikitext.`)
+    process.exit(0)
+  }
+
+  console.log(`Parsing wikitext (${wikitext.length} chars)…`)
+  const incoming = parseWikitext(wikitext)
+  console.log(`Found ${incoming.length} task(s) in wikitext.`)
+
+  const outDir = path.resolve(
+    __dirname,
+    '../data/raw',
+    league,
+  )
+  fs.mkdirSync(outDir, { recursive: true })
+  const outPath = path.join(outDir, 'raw-tasks.json')
+
+  const existing = readExistingTasks(outPath)
+  const merged = mergeTasks(existing, incoming)
+
+  fs.writeFileSync(outPath, JSON.stringify(merged, null, 2), 'utf-8')
+  console.log(`Wrote ${merged.length} task(s) to ${outPath}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/schemas/core.ts
+++ b/src/schemas/core.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod'
-import { LocationSchema, TaskLocationSchema } from './location.js'
 
 export const SkillSchema = z.enum([
   'Attack',
@@ -57,8 +56,6 @@ export const LeagueSchema = z.object({
   regions: z.array(RegionSchema),
   tasks: z.array(TaskSchema),
   pointTiers: z.array(PointTierSchema),
-  locations: z.array(LocationSchema).optional(),
-  taskLocations: z.array(TaskLocationSchema).optional(),
 })
 
 export type Skill = z.infer<typeof SkillSchema>

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,2 +1,1 @@
 export * from './core.js'
-export * from './location.js'


### PR DESCRIPTION
## Assembly Layer 1 — Raw Scrapers

Rate-limited wiki API client with disk cache, plus task and location scrapers.

### Deliverables
- `scripts/lib/wiki-client.ts` — 1 req/s rate limiter, SHA-256 disk cache at data/raw/.cache/
- `scripts/scrape-tasks.ts` — scrapes league task table, incremental merge by task name
- `scripts/scrape-locations.ts` — scrapes map markers by activity category
- `data/raw/category-map.json` — wiki category → ActivityType mapping

### Acceptance criteria
- [x] Scripts type-check cleanly (tsc --noEmit exits 0)
- [x] wikiRequest caches responses; re-run makes 0 HTTP requests
- [x] Scraper exits non-zero on HTTP errors
- [x] scrape-tasks.ts merges new tasks without modifying existing entries