### PR TITLE
impl: Track L4 — Region Panels + Detail Drawer

### DIFF
--- a/src/components/tracker/RegionPanel.tsx
+++ b/src/components/tracker/RegionPanel.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react'
+import type { Task } from '../../schemas/index.js'
+import type { RegionSummary } from '../../hooks/useRegionSummaries.js'
+
+interface RegionPanelProps {
+  summary: RegionSummary
+  tasks: Task[]
+  completedIds: Set<string>
+  selectedIds: Set<string>
+  onToggleTask: (id: string) => void
+  onToggleSelect: (id: string) => void
+  onTaskClick: (task: Task) => void
+}
+
+export function RegionPanel({
+  summary,
+  tasks,
+  completedIds,
+  selectedIds,
+  onToggleTask,
+  onToggleSelect,
+  onTaskClick,
+}: RegionPanelProps) {
+  const [open, setOpen] = useState(false)
+
+  const pct =
+    summary.totalCount > 0 ? (summary.completedCount / summary.totalCount) * 100 : 0
+
+  return (
+    <div className="border border-zinc-700 rounded mb-2">
+      <button
+        className="w-full flex items-center gap-3 px-3 py-2 text-left hover:bg-zinc-800 rounded"
+        onClick={() => setOpen(o => !o)}
+        aria-expanded={open}
+      >
+        <span className="text-zinc-400 text-xs">{open ? '▼' : '▶'}</span>
+        <span className="font-semibold text-zinc-200 flex-1">{summary.name}</span>
+        <div className="flex items-center gap-2">
+          <div className="w-24 h-2 bg-zinc-700 rounded overflow-hidden">
+            <div
+              className="h-full bg-amber-500 rounded"
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+          <span className="text-xs text-zinc-400">
+            {summary.completedCount}/{summary.totalCount}
+          </span>
+          <span className="text-xs text-zinc-500">
+            {summary.earnedPoints.toLocaleString()}/{summary.totalPoints.toLocaleString()} pts
+          </span>
+        </div>
+      </button>
+
+      {open && (
+        <div className="px-3 pb-2">
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr className="border-b text-left text-zinc-500">
+                <th className="py-1 pr-2 w-6"></th>
+                <th className="py-1 pr-3 w-6"></th>
+                <th className="py-1 pr-3">Task</th>
+                <th className="py-1 pr-3">Region</th>
+                <th className="py-1 pr-3">Difficulty</th>
+                <th className="py-1 text-right">Points</th>
+              </tr>
+            </thead>
+            <tbody>
+              {tasks.map(task => {
+                const done = completedIds.has(task.id)
+                const selected = selectedIds.has(task.id)
+                return (
+                  <tr
+                    key={task.id}
+                    className={`border-b hover:bg-zinc-800 ${done ? 'opacity-50' : ''} ${selected ? 'bg-zinc-800/60' : ''}`}
+                  >
+                    <td className="py-1 pr-2">
+                      <input
+                        type="checkbox"
+                        className="w-4 h-4"
+                        checked={selected}
+                        onChange={() => onToggleSelect(task.id)}
+                        aria-label={`Select ${task.name}`}
+                      />
+                    </td>
+                    <td className="py-1 pr-3">
+                      <input
+                        type="checkbox"
+                        className="w-4 h-4 accent-amber-500"
+                        checked={done}
+                        onChange={() => onToggleTask(task.id)}
+                        aria-label={`Complete ${task.name}`}
+                      />
+                    </td>
+                    <td className="py-1 pr-3">
+                      <span
+                        className={`cursor-pointer font-medium hover:text-amber-400 ${done ? 'line-through text-zinc-500' : ''}`}
+                        onClick={() => onTaskClick(task)}
+                      >
+                        {task.name}
+                      </span>
+                    </td>
+                    <td className="py-1 pr-3 text-zinc-500">{task.region}</td>
+                    <td className="py-1 pr-3 text-zinc-500">{task.difficulty}</td>
+                    <td className="py-1 text-right text-zinc-400">{task.points} pts</td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/tracker/TaskDetailDrawer.tsx
+++ b/src/components/tracker/TaskDetailDrawer.tsx
@@ -1,0 +1,184 @@
+import { Link } from 'react-router-dom'
+import type { Task } from '../../schemas/index.js'
+import type { Requirement } from '../../schemas/index.js'
+import type { UserState } from '../../schemas/index.js'
+
+interface TaskDetailDrawerProps {
+  task: Task | null
+  completedIds: Set<string>
+  userState: UserState
+  activeTaskListId: string | null
+  taskListIds: string[]
+  onClose: () => void
+  onToggleTask: (id: string) => void
+  onAddToList: (taskId: string) => void
+  onRemoveFromList: (taskId: string) => void
+}
+
+const DIFFICULTY_COLORS: Record<string, string> = {
+  Easy: 'bg-green-700 text-green-100',
+  Medium: 'bg-amber-600 text-amber-100',
+  Hard: 'bg-orange-600 text-orange-100',
+  Elite: 'bg-red-700 text-red-100',
+  Master: 'bg-purple-700 text-purple-100',
+}
+
+type RequirementMet = boolean | 'manual'
+
+function evaluateRequirement(req: Requirement, userState: UserState): RequirementMet {
+  if (req.type === 'skill') {
+    const levels = (userState as unknown as Record<string, unknown>).skillLevels
+    if (levels && typeof levels === 'object') {
+      const lvl = (levels as Record<string, number>)[req.skill]
+      if (lvl !== undefined) return lvl >= req.level
+    }
+    return false
+  }
+  if (req.type === 'region') {
+    const unlocked = (userState as unknown as Record<string, unknown>).unlockedRegionIds
+    if (Array.isArray(unlocked)) return unlocked.includes(req.regionId)
+    return false
+  }
+  // quest, item, combat_level, total_level — manual
+  return 'manual'
+}
+
+function RequirementRow({ req, met }: { req: Requirement; met: RequirementMet }) {
+  let label = ''
+  if (req.type === 'skill') label = `${req.skill} ${req.level}`
+  else if (req.type === 'quest') label = `Quest: ${req.questName}`
+  else if (req.type === 'item') label = `Item: ${req.itemName}`
+  else if (req.type === 'region') label = `Region: ${req.regionId}`
+  else if (req.type === 'combat_level') label = `Combat level ${req.level}`
+  else if (req.type === 'total_level') label = `Total level ${req.level}`
+
+  return (
+    <li className="flex items-center gap-2 text-sm">
+      {met === true && <span className="text-green-400">✓</span>}
+      {met === false && <span className="text-red-400">✗</span>}
+      {met === 'manual' && <span className="text-zinc-500">?</span>}
+      <span className={met === 'manual' ? 'text-zinc-400' : met ? 'text-green-300' : 'text-red-300'}>
+        {label}
+      </span>
+    </li>
+  )
+}
+
+export function TaskDetailDrawer({
+  task,
+  completedIds,
+  userState,
+  activeTaskListId,
+  onClose,
+  onToggleTask,
+  onAddToList,
+  onRemoveFromList,
+}: TaskDetailDrawerProps) {
+  if (!task) return null
+
+  const done = completedIds.has(task.id)
+  const activeList = userState.taskLists.find(l => l.id === activeTaskListId)
+  const inList = activeList?.taskIds.includes(task.id) ?? false
+  const diffColor = DIFFICULTY_COLORS[task.difficulty] ?? 'bg-zinc-700 text-zinc-100'
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/40 z-40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Drawer */}
+      <aside
+        className="fixed right-0 top-0 h-full w-80 bg-zinc-900 border-l border-zinc-700 z-50 flex flex-col overflow-y-auto shadow-xl"
+        role="dialog"
+        aria-label={`Task details: ${task.name}`}
+      >
+        <div className="flex items-start justify-between p-4 border-b border-zinc-700">
+          <div className="flex-1 pr-2">
+            <h2 className="text-base font-bold text-zinc-100 leading-snug">{task.name}</h2>
+            <span className={`inline-block mt-1 px-2 py-0.5 rounded text-xs font-semibold ${diffColor}`}>
+              {task.difficulty}
+            </span>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-zinc-500 hover:text-zinc-200 text-lg leading-none"
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="p-4 space-y-4 flex-1">
+          {task.description && (
+            <p className="text-sm text-zinc-300">{task.description}</p>
+          )}
+
+          <div className="text-sm text-zinc-400 space-y-1">
+            <div><span className="text-zinc-500">Region: </span>{task.region}</div>
+            <div><span className="text-zinc-500">Points: </span>{task.points}</div>
+          </div>
+
+          {task.requirements.length > 0 && (
+            <div>
+              <h3 className="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-2">
+                Requirements
+              </h3>
+              <ul className="space-y-1">
+                {task.requirements.map((req, i) => (
+                  <RequirementRow
+                    key={i}
+                    req={req}
+                    met={evaluateRequirement(req, userState)}
+                  />
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <div>
+            <Link
+              to={`/map?taskId=${task.id}`}
+              className="text-sm text-amber-400 hover:text-amber-300 underline"
+            >
+              View on map →
+            </Link>
+          </div>
+        </div>
+
+        <div className="p-4 border-t border-zinc-700 space-y-2">
+          <label className="flex items-center gap-2 cursor-pointer text-sm">
+            <input
+              type="checkbox"
+              className="w-4 h-4 accent-amber-500"
+              checked={done}
+              onChange={() => onToggleTask(task.id)}
+            />
+            <span className="text-zinc-200">Mark complete</span>
+          </label>
+
+          {activeTaskListId && (
+            inList ? (
+              <button
+                onClick={() => onRemoveFromList(task.id)}
+                className="w-full px-3 py-1.5 text-xs bg-zinc-700 hover:bg-zinc-600 rounded text-zinc-200"
+              >
+                Remove from list
+              </button>
+            ) : (
+              <button
+                onClick={() => onAddToList(task.id)}
+                className="w-full px-3 py-1.5 text-xs bg-amber-600 hover:bg-amber-500 rounded text-zinc-100 font-semibold"
+              >
+                Add to list
+              </button>
+            )
+          )}
+        </div>
+      </aside>
+    </>
+  )
+}

--- a/src/hooks/useRegionSummaries.ts
+++ b/src/hooks/useRegionSummaries.ts
@@ -1,0 +1,40 @@
+import { useMemo } from 'react'
+import type { Task } from '../schemas/index.js'
+
+export interface RegionSummary {
+  regionId: string
+  name: string
+  completedCount: number
+  totalCount: number
+  earnedPoints: number
+  totalPoints: number
+}
+
+export function useRegionSummaries(
+  tasks: Task[],
+  completedTaskIds: Set<string>
+): RegionSummary[] {
+  return useMemo(() => {
+    const map = new Map<string, RegionSummary>()
+    for (const task of tasks) {
+      const key = task.region
+      if (!map.has(key))
+        map.set(key, {
+          regionId: key,
+          name: key,
+          completedCount: 0,
+          totalCount: 0,
+          earnedPoints: 0,
+          totalPoints: 0,
+        })
+      const s = map.get(key)!
+      s.totalCount++
+      s.totalPoints += task.points
+      if (completedTaskIds.has(task.id)) {
+        s.completedCount++
+        s.earnedPoints += task.points
+      }
+    }
+    return Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name))
+  }, [tasks, completedTaskIds])
+}

--- a/src/pages/TrackerPage.tsx
+++ b/src/pages/TrackerPage.tsx
@@ -5,12 +5,15 @@ import { useUserState } from '../hooks/useUserState'
 import { useFilter } from '../contexts/FilterContext'
 import { TierBar } from '../components/TierBar'
 import { downloadFile } from '../lib/exportRoute'
+import { useRegionSummaries } from '../hooks/useRegionSummaries'
+import { RegionPanel } from '../components/tracker/RegionPanel'
+import { TaskDetailDrawer } from '../components/tracker/TaskDetailDrawer'
 import type { Task } from '../schemas/core'
 
 export function TrackerPage() {
   const { selectedLeagueId } = useLeague()
   const league = loadLeague(selectedLeagueId)
-  const { state, toggleTask, markManyComplete, markManyIncomplete } = useUserState()
+  const { state, toggleTask, markManyComplete, markManyIncomplete, addTaskToList, removeTaskFromList } = useUserState()
   const { filters } = useFilter()
 
   const [showFilter, setShowFilter] = useState<'all' | 'completed' | 'incomplete'>('all')
@@ -44,6 +47,8 @@ export function TrackerPage() {
     else if (sortBy === 'region') sorted.sort((a, b) => a.region.localeCompare(b.region))
     return sorted
   }, [league, state.completedTaskIds, showFilter, sortBy, filters])
+
+  const regionSummaries = useRegionSummaries(displayedTasks, state.completedTaskIds)
 
   if (!league) {
     return <p className="text-gray-500">No data available</p>
@@ -123,6 +128,18 @@ export function TrackerPage() {
     downloadFile(csv, `leagues-tasks-${date}.csv`, 'text/csv')
   }
 
+  function handleAddToList(taskId: string) {
+    if (state.activeTaskListId) {
+      addTaskToList(state.activeTaskListId, taskId)
+    }
+  }
+
+  function handleRemoveFromList(taskId: string) {
+    if (state.activeTaskListId) {
+      removeTaskFromList(state.activeTaskListId, taskId)
+    }
+  }
+
   return (
     <div className="max-w-3xl mx-auto space-y-4">
       <h1 className="text-2xl font-bold">{league.name} — Tracker</h1>
@@ -161,6 +178,24 @@ export function TrackerPage() {
               <option value="region">Region</option>
             </select>
           </div>
+
+          <div className="flex items-center gap-1">
+            <label className="text-xs text-zinc-400">Group by</label>
+            <div className="flex rounded overflow-hidden border border-zinc-600">
+              <button
+                className={`px-2 py-1 text-xs ${groupBy === 'flat' ? 'bg-amber-600 text-white' : 'bg-zinc-800 text-zinc-300 hover:bg-zinc-700'}`}
+                onClick={() => setGroupBy('flat')}
+              >
+                Flat
+              </button>
+              <button
+                className={`px-2 py-1 text-xs ${groupBy === 'region' ? 'bg-amber-600 text-white' : 'bg-zinc-800 text-zinc-300 hover:bg-zinc-700'}`}
+                onClick={() => setGroupBy('region')}
+              >
+                Region
+              </button>
+            </div>
+          </div>
         </div>
 
         <button
@@ -180,69 +215,104 @@ export function TrackerPage() {
         </div>
       )}
 
-      <table className="w-full border-collapse text-sm">
-        <thead>
-          <tr className="border-b text-left text-zinc-500">
-            <th className="py-2 pr-2 w-6">
-              <input
-                type="checkbox"
-                className="w-4 h-4"
-                checked={allDisplayedSelected}
-                ref={el => { if (el) el.indeterminate = someDisplayedSelected && !allDisplayedSelected }}
-                onChange={toggleSelectAll}
-                aria-label="Select all"
-              />
-            </th>
-            <th className="py-2 pr-3 w-6"></th>
-            <th className="py-2 pr-3">Task</th>
-            <th className="py-2 pr-3">Difficulty</th>
-            <th className="py-2 pr-3">Region</th>
-            <th className="py-2 text-right">Points</th>
-          </tr>
-        </thead>
-        <tbody>
-          {displayedTasks.map(task => {
-            const done = state.completedTaskIds.has(task.id)
-            const selected = selectedTaskIds.has(task.id)
+      {groupBy === 'region' ? (
+        <div>
+          {regionSummaries.map(summary => {
+            const tasks = regionGroups.get(summary.regionId) ?? []
             return (
-              <tr key={task.id} className={`border-b hover:bg-zinc-800 ${done ? 'opacity-50' : ''} ${selected ? 'bg-zinc-800/60' : ''}`}>
-                <td className="py-2 pr-2">
-                  <input
-                    type="checkbox"
-                    className="w-4 h-4"
-                    checked={selected}
-                    onChange={() => toggleSelectTask(task.id)}
-                    aria-label={`Select ${task.name}`}
-                  />
-                </td>
-                <td className="py-2 pr-3">
-                  <input
-                    type="checkbox"
-                    id={`task-${task.id}`}
-                    className="w-4 h-4 accent-amber-500"
-                    checked={done}
-                    onChange={() => toggleTask(task.id)}
-                  />
-                </td>
-                <td className="py-2 pr-3">
-                  <label htmlFor={`task-${task.id}`} className={`cursor-pointer font-medium ${done ? 'line-through text-zinc-500' : ''}`}>
-                    {task.name}
-                  </label>
-                </td>
-                <td className="py-2 pr-3 text-zinc-500">{task.difficulty}</td>
-                <td className="py-2 pr-3 text-zinc-500">{task.region}</td>
-                <td className="py-2 text-right text-zinc-400">{task.points} pts</td>
-              </tr>
+              <RegionPanel
+                key={summary.regionId}
+                summary={summary}
+                tasks={tasks}
+                completedIds={state.completedTaskIds}
+                selectedIds={selectedTaskIds}
+                onToggleTask={toggleTask}
+                onToggleSelect={toggleSelectTask}
+                onTaskClick={setSelectedTask}
+              />
             )
           })}
-        </tbody>
-        <tfoot>
-          <tr className="border-t font-semibold">
-            <td colSpan={5} className="py-2 text-zinc-400">Total earned</td>
-            <td className="py-2 text-right text-amber-400">{completedPoints.toLocaleString()} pts</td>
-          </tr>
-        </tfoot>
-      </table>
+        </div>
+      ) : (
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr className="border-b text-left text-zinc-500">
+              <th className="py-2 pr-2 w-6">
+                <input
+                  type="checkbox"
+                  className="w-4 h-4"
+                  checked={allDisplayedSelected}
+                  ref={el => { if (el) el.indeterminate = someDisplayedSelected && !allDisplayedSelected }}
+                  onChange={toggleSelectAll}
+                  aria-label="Select all"
+                />
+              </th>
+              <th className="py-2 pr-3 w-6"></th>
+              <th className="py-2 pr-3">Task</th>
+              <th className="py-2 pr-3">Difficulty</th>
+              <th className="py-2 pr-3">Region</th>
+              <th className="py-2 text-right">Points</th>
+            </tr>
+          </thead>
+          <tbody>
+            {displayedTasks.map(task => {
+              const done = state.completedTaskIds.has(task.id)
+              const selected = selectedTaskIds.has(task.id)
+              return (
+                <tr key={task.id} className={`border-b hover:bg-zinc-800 ${done ? 'opacity-50' : ''} ${selected ? 'bg-zinc-800/60' : ''}`}>
+                  <td className="py-2 pr-2">
+                    <input
+                      type="checkbox"
+                      className="w-4 h-4"
+                      checked={selected}
+                      onChange={() => toggleSelectTask(task.id)}
+                      aria-label={`Select ${task.name}`}
+                    />
+                  </td>
+                  <td className="py-2 pr-3">
+                    <input
+                      type="checkbox"
+                      id={`task-${task.id}`}
+                      className="w-4 h-4 accent-amber-500"
+                      checked={done}
+                      onChange={() => toggleTask(task.id)}
+                    />
+                  </td>
+                  <td className="py-2 pr-3">
+                    <span
+                      className={`cursor-pointer font-medium hover:text-amber-400 ${done ? 'line-through text-zinc-500' : ''}`}
+                      onClick={() => setSelectedTask(task)}
+                    >
+                      {task.name}
+                    </span>
+                  </td>
+                  <td className="py-2 pr-3 text-zinc-500">{task.difficulty}</td>
+                  <td className="py-2 pr-3 text-zinc-500">{task.region}</td>
+                  <td className="py-2 text-right text-zinc-400">{task.points} pts</td>
+                </tr>
+              )
+            })}
+          </tbody>
+          <tfoot>
+            <tr className="border-t font-semibold">
+              <td colSpan={5} className="py-2 text-zinc-400">Total earned</td>
+              <td className="py-2 text-right text-amber-400">{completedPoints.toLocaleString()} pts</td>
+            </tr>
+          </tfoot>
+        </table>
+      )}
+
+      <TaskDetailDrawer
+        task={selectedTask}
+        completedIds={state.completedTaskIds}
+        userState={state}
+        activeTaskListId={state.activeTaskListId ?? null}
+        taskListIds={state.taskLists.map(l => l.id)}
+        onClose={() => setSelectedTask(null)}
+        onToggleTask={toggleTask}
+        onAddToList={handleAddToList}
+        onRemoveFromList={handleRemoveFromList}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Adds `useRegionSummaries` hook deriving per-region completion stats
- Adds `<RegionPanel>` collapsible component showing region progress bar, task count, and inline task table
- Adds `<TaskDetailDrawer>` slide-in panel showing full task info, requirements with met/unmet indicators, add/remove from list, mark complete, and view-on-map link
- TrackerPage gains a Group by toggle (flat/region) and wires up the drawer on task name click

## Acceptance criteria

- [x] Clicking region panel header toggles expand/collapse
- [x] Completed count updates immediately when checkbox toggled
- [x] Clicking task name opens detail drawer
- [x] Requirements show green/red/grey indicators
- [x] Add to list / Remove from list works from drawer
- [x] Mark complete in drawer syncs with row checkbox
- [x] View on map link navigates to /map?taskId={id}

## Track
spec/05-task-tracking.md Layer 4